### PR TITLE
use alternative to "morphs" for uuid

### DIFF
--- a/database/migrations/2024_10_02_175547_create_personal_access_tokens_table.php
+++ b/database/migrations/2024_10_02_175547_create_personal_access_tokens_table.php
@@ -13,8 +13,7 @@ return new class extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
-            $table->string('tokenable_id', 36);
-            $table->string('tokenable_type');
+            $table->uuidMorphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();


### PR DESCRIPTION
Una alternativa al cambio en 11f3b2abeee1e3cfcfdf73eee13b1b010d8f0f3e, el resultado es prácticamente el mismo, pero sin perder la "expresividad" de usar el método de Laravel con el nombre apropiado a la situación.