### PR TITLE
Use Form Request Validation

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreCourseRequest;
+use App\Http\Requests\UpdateCourseRequest;
 use App\Models\Course;
 use Illuminate\Http\Request;
 
@@ -18,12 +20,8 @@ class CourseController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreCourseRequest $request)
     {
-        $request->validate([
-            'name' => 'required',
-        ]);
-
         $course = Course::create($request->all());
 
         return response()->json($course, 201);
@@ -46,17 +44,13 @@ class CourseController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(UpdateCourseRequest $request, string $id)
     {
         $course = Course::find($id);
 
         if (!$course) {
             return response()->json(['message' => 'Course not found'], 404);
         }
-
-        $request->validate([
-            'name' => 'required',
-        ]);
 
         $course->update($request->all());
 

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -22,7 +22,7 @@ class CourseController extends Controller
      */
     public function store(StoreCourseRequest $request)
     {
-        $course = Course::create($request->all());
+        $course = Course::create($request->validated());
 
         return response()->json($course, 201);
     }
@@ -52,7 +52,7 @@ class CourseController extends Controller
             return response()->json(['message' => 'Course not found'], 404);
         }
 
-        $course->update($request->all());
+        $course->update($request->validated());
 
         return response()->json($course);
     }

--- a/app/Http/Requests/StoreCourseRequest.php
+++ b/app/Http/Requests/StoreCourseRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCourseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateCourseRequest.php
+++ b/app/Http/Requests/UpdateCourseRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCourseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+}


### PR DESCRIPTION
Una herramienta interesante de Laravel para la validación es usar los [Form Requests Validations](https://laravel.com/docs/11.x/validation#form-request-validation) que permiten definir todas las reglas de validación en un punto común. 

Con esto nos ahorramos tener que manejar nosotros esa lógica dentro del controller y podemos asumir que los datos que llegan al controller ya llegan superando la validación correspondiente.

Otro detalle es usar sólo los datos validados (definidos en las reglas de validación) al momento de crear un nuevo modelo, para evitar una situación donde el usuario envía datos mal intencionados o mal formados y esos datos se persistan en la BD. Para esto igualmente Laravel ofrece una segunda barrera de protección que es definir los campos que pueden ser _[mass assignable](https://laravel.com/docs/11.x/eloquent#mass-assignment)_ a nivel modelo.

> Nota: Hice los cambios sólo en un controller, queda como ejercicio al lector cambiar el resto (?