### PR TITLE
update layout spacing

### DIFF
--- a/resources/js/Layouts/Layout.vue
+++ b/resources/js/Layouts/Layout.vue
@@ -5,23 +5,29 @@ import FooterComponent from './components/FooterComponent.vue';
 </script>
 
 <template>
-  <div class="row g-0 min-vh-100">
-    <aside class="d-none d-md-block col-md-4 col-lg-3 col-xxl-2">
-      <MainSidebar />
-    </aside>
-    
-    <div class="col">
-      <header>
-        <MainNavbar />
-      </header>
-      
-      <main class="bg-light m-2 m-sm-3 p-3 p-lg-5 border rounded">
-        <slot>
-          <!-- Page content -->
-        </slot>
-      </main>
-      
-      <FooterComponent />
+  <div class="m-3">
+    <div class="row g-3">
+      <aside class="d-none d-md-block col-4 col-lg-3 col-xxl-2">
+        <MainSidebar />
+      </aside>
+
+      <div class="col-12 col-md-8 col-lg-9 col-xxl-10">
+        <MainNavbar class="mb-3 p-3" />
+
+        <main class="bg-light border rounded p-3">
+          <slot>
+            <!-- Page content -->
+          </slot>
+        </main>
+
+        <FooterComponent />
+      </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+aside {
+  min-height: calc(100vh - 2rem);
+}
+</style>

--- a/resources/js/Layouts/components/MainNavbar.vue
+++ b/resources/js/Layouts/components/MainNavbar.vue
@@ -3,16 +3,16 @@ import LinkList from './LinkList.vue';
 </script>
 
 <template>
-  <nav class="navbar navbar-expand-md bg-light rounded border m-sm-3 p-sm-3">
-    <div class="container-fluid d-flex justify-content-between text-align-middle">
+  <nav class="navbar navbar-expand-md bg-light rounded border">
+    <div class="d-flex w-100 flex-wrap justify-content-between text-align-middle">
       <!-- Header -->
-      <div class="d-flex">
-        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu"
+      <div class="d-flex align-items-center">
+        <button class="navbar-toggler me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasMenu"
           aria-controls="offcanvasMenu" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
 
-        <h2 class="fs-4 pt-2 mx-3">Dashboard</h2>
+        <h2 class="fs-4 m-0">Dashboard</h2>
       </div>
       <div class="d-flex align-items-center">
         <img src="https://ui-avatars.com/api/?name=Some+User" alt="Profile picture" height="40" width="40" class="rounded-circle me-2" />

--- a/resources/js/Layouts/components/MainSidebar.vue
+++ b/resources/js/Layouts/components/MainSidebar.vue
@@ -4,14 +4,12 @@ import LinkList from './LinkList.vue';
 </script>
 
 <template>
-  <nav class="bg-light rounded border h-100 m-3 p-3">
-    <header class="py-2">
-      <Link class="navbar-brand fs-4" href="/">
-        <img :src="'assets/images/subjectLogo.png'" alt="Logo" width="30" height="30"
-          class="d-inline-block align-text-middle">
-        Grade Helper
-      </Link>
-    </header>
+  <nav class="bg-light rounded border h-100 p-3">
+    <Link class="navbar-brand fs-4" href="/">
+      <img :src="'assets/images/subjectLogo.png'" alt="Logo" width="30" height="30"
+        class="d-inline-block align-text-middle">
+      Grade Helper
+    </Link>
     <LinkList />
   </nav>
 </template>


### PR DESCRIPTION
Modifico la forma en que se distribuye el espacio en el layout.

En general la idea es que los padres deciden sobre los hijos (aunque una vez que arranqué con eso fuí moviendo espacios por todos lados).

Por ejemplo: elimino espacios y margenes de cada elemento, y agrego esos mismos espacios y margenes en el elemento padre.

También agrego una regla CSS para que el sidebar ocupe todo el alto de la página, pero sin agregar scroll :chef-kiss: