### PR TITLE
Fulfill course students section

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -44,7 +44,7 @@ class CourseController extends Controller
     public function show(Course $course)
     {
         return Inertia::render('Courses/Show', [
-            'course' => $course->load('exercises')
+            'course' => $course->load(['students.course', 'exercises'])
         ]);
     }
 

--- a/resources/js/Layouts/components/MainSidebar.vue
+++ b/resources/js/Layouts/components/MainSidebar.vue
@@ -6,7 +6,7 @@ import LinkList from './LinkList.vue';
 <template>
   <nav class="bg-light rounded border h-100 p-3">
     <Link class="navbar-brand fs-4" href="/">
-      <img :src="'assets/images/subjectLogo.png'" alt="Logo" width="30" height="30"
+      <img :src="'/assets/images/subjectLogo.png'" alt="Logo" width="30" height="30"
         class="d-inline-block align-text-middle">
       Grade Helper
     </Link>

--- a/resources/js/Pages/Courses/Show.vue
+++ b/resources/js/Pages/Courses/Show.vue
@@ -1,4 +1,6 @@
 <script setup>
+import StudentsList from '../Students/Index.vue';
+
 const props = defineProps({ course: Object })
 
 const sortedCourseExercises = props.course.exercises.sort((a, b) => a.title.localeCompare(b.title))
@@ -25,8 +27,7 @@ const sortedCourseExercises = props.course.exercises.sort((a, b) => a.title.loca
   <div class="tab-content p-3" id="courseTabsContent">
     <div class="tab-pane fade show active" id="students-tab-pane" role="tabpanel" aria-labelledby="students-tab"
       tabindex="0">
-      <h2 class="mb-3 ">Students</h2>
-      <!-- <StudentsList :course_id="course.id" /> --><!-- Course id is intended to be passed to the StudentsList component -->
+      <StudentsList :students="course.students" />
     </div>
     
     <div class="tab-pane fade" id="exercises-tab-pane" role="tabpanel" aria-labelledby="exercises-tab" tabindex="0">

--- a/resources/js/Pages/Students/components/CreateStudentForm.vue
+++ b/resources/js/Pages/Students/components/CreateStudentForm.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { useForm, usePage } from '@inertiajs/vue3';
 
-
 const form = useForm({
   first_name: '',
   last_name: '',
@@ -12,6 +11,14 @@ const form = useForm({
 // Get courses information
 const page = usePage()
 const courses = page.props.courses
+
+// Get current course if on the course page
+const courseUrlParam = page.url.split('/')[2]
+const currentCourse = courses.find(course => course.id === courseUrlParam)
+
+if (currentCourse) {
+  form.course_id = currentCourse.id
+}
 
 function submit() {
   form.post('/students', {


### PR DESCRIPTION
Agrego la capacidad de listar los estudiantes de un curso dentro del apartado específico del mismo

La funcionalidad para listar notas se hará en un PR separado ya que parte de la lógica desprende de una rama (`student-details`) aún en revisión

Ademas aprovecho a corregir el path del logo en el sidebar