### PR TITLE
Admin commands

### DIFF
--- a/app/Console/Commands/ToggleAdmin.php
+++ b/app/Console/Commands/ToggleAdmin.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class ToggleAdmin extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:toggle-admin {email}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $email = $this->argument('email');
+        $user = User::where('email', $email)->first();
+
+        if (!$user) {
+            $this->error("User with email {$email} not found.");
+            return;
+        }
+
+        if ($user->hasRole('admin')) {
+            $user->removeRole('admin');
+            $this->info("User {$email} is no longer an admin.");
+            return;
+        }
+
+        $user->assignRole('admin');
+        $this->info("User {$email} has been assigned the admin role.");
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -11,6 +11,10 @@ class HomeController extends Controller
   {
     $student = $request->user()->student;
 
+    if (!$student) {
+      return Inertia::render('Home/HomeView');
+    }
+
     $student->load([
       'course',
       'course.assessments.exercise',

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,14 +34,4 @@ Route::middleware('auth')->group(function () {
     });
 });
 
-Route::get('/giveMeIOMA', function (Request $request) {
-    $request->user()->assignRole('admin');
-    return redirect()->back()->with('success', 'You are now an admin');
-});
-
-Route::get('/javierAppeared', function (Request $request) {
-    $request->user()->removeRole('admin');
-    return redirect()->back()->with('success', 'You are no longer an admin');
-})->middleware('admin');
-
 require __DIR__.'/auth.php';


### PR DESCRIPTION
fix #85. Ahora el admin se activa/desactiva mediante un comando en terminal:
```
php artisan app:toggle-admin { email }
```

Además aprovecho a arreglar el `HomeController`, que se rompía si no había un estudiante asignado al usuario